### PR TITLE
Revert "Changes to fix crashing in gdb debugging"

### DIFF
--- a/bfd/elf32-mips.c
+++ b/bfd/elf32-mips.c
@@ -1840,7 +1840,7 @@ _bfd_mips_elf_final_write_processing (abfd, linker)
       break;
 
     case 6000:
-      val = E_MIPS_ARCH_6;
+      val = E_MIPS_ARCH_2;
       break;
 
     case 4000:
@@ -2296,14 +2296,6 @@ _bfd_mips_elf_fake_sections (abfd, hdr, sec)
 	hdr->sh_entsize = 0;
       else
 	hdr->sh_entsize = 1;
-    }
-  else if (strcmp (name, ".MIPS.abiflags") == 0)
-    {
-      hdr->sh_type = SHT_MIPS_ABIFLAGS;
-      hdr->sh_entsize = 0x18;
-
-      /* Force the section size to the correct value */
-      hdr->sh_size = sec->_raw_size = 0x18;
     }
   else if (strcmp (name, ".reginfo") == 0)
     {

--- a/gas/config/obj-elf.c
+++ b/gas/config/obj-elf.c
@@ -1504,18 +1504,15 @@ elf_frob_file_after_relocs ()
 	as_fatal ("Failed to set up debugging information: %s",
 		  bfd_errmsg (bfd_get_error ()));
 
-      /*
       sec = bfd_get_section_by_name (stdoutput, ".mdebug");
       assert (sec != NULL);
 
       know (stdoutput->output_has_begun == false);
-      */
 
       /* We set the size of the section, call bfd_set_section_contents
 	 to force the ELF backend to allocate a file position, and then
 	 write out the data.  FIXME: Is this really the best way to do
 	 this?  */
-   /*
       sec->_raw_size = bfd_ecoff_debug_size (stdoutput, &debug, debug_swap);
 
       if (! bfd_set_section_contents (stdoutput, sec, (PTR) NULL,
@@ -1530,7 +1527,6 @@ elf_frob_file_after_relocs ()
 				   sec->filepos))
 	as_fatal ("Could not write .mdebug section: %s",
 		  bfd_errmsg (bfd_get_error ()));
-      */
     }
 #endif /* NEED_ECOFF_DEBUG */
 }

--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -1351,12 +1351,6 @@ md_begin ()
 	subsegT subseg;
 	flagword flags;
 	segT sec;
-	char abidata[0x18];
-
-	memset(abidata, 0, sizeof(abidata));
-	*(int *)(&abidata[2]) = 0x01010140;
-	abidata[7] = 0x01;
-	abidata[0x13] = 0x01;
 
 	seg = now_seg;
 	subseg = now_subseg;
@@ -1367,12 +1361,6 @@ md_begin ()
 	flags = SEC_READONLY | SEC_DATA;
 	if (strcmp (TARGET_OS, "elf") != 0)
 	  flags |= SEC_ALLOC | SEC_LOAD;
-
-	sec = subseg_new (".MIPS.abiflags", (subsegT) 0);
-
-	(void) bfd_set_section_flags (stdoutput, sec, flags);
-	(void) bfd_set_section_alignment (stdoutput, sec, 3);
-	memcpy(frag_more(0x18), abidata, sizeof(abidata));
 
 	if (! mips_64)
 	  {
@@ -1414,7 +1402,7 @@ md_begin ()
 #endif
 	  }
 
-	if (0) // (ECOFF_DEBUGGING)
+	if (ECOFF_DEBUGGING)
 	  {
 	    sec = subseg_new (".mdebug", (subsegT) 0);
 	    (void) bfd_set_section_flags (stdoutput, sec,
@@ -11439,8 +11427,6 @@ mips_elf_final_processing ()
     elf_elfheader (stdoutput)->e_flags |= EF_MIPS_NOREORDER;
   if (mips_pic != NO_PIC)
     elf_elfheader (stdoutput)->e_flags |= EF_MIPS_PIC;
-
-    elf_elfheader (stdoutput)->e_flags = 0x60001101;
 }
 
 #endif /* OBJ_ELF || OBJ_MAYBE_ELF */

--- a/include/elf/mips.h
+++ b/include/elf/mips.h
@@ -56,9 +56,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 /* -mips4 code.  */
 #define E_MIPS_ARCH_4		0x30000000
-
-/* -mips64 code.  */
-#define E_MIPS_ARCH_6		0x60000000
 
 /* Processor specific section indices.  These sections do not actually
    exist.  Symbols with a st_shndx field corresponding to one of these
@@ -126,9 +123,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 /* Events section.  */
 #define SHT_MIPS_EVENTS		0x70000021
-
-/* ABI related flags section.  */
-#define SHT_MIPS_ABIFLAGS       0x7000002a
 
 /* A section of type SHT_MIPS_LIBLIST contains an array of the
    following structure.  The sh_link field is the section index of the


### PR DESCRIPTION
Reverts pmret/binutils-papermario#7

Doing this for now, since we're not getting source code line numbers anymore with this change