### PR TITLE
Alter generation of object files to be compatible with latest gdb debugger

### DIFF
--- a/bfd/elf32-mips.c
+++ b/bfd/elf32-mips.c
@@ -1840,7 +1840,7 @@ _bfd_mips_elf_final_write_processing (abfd, linker)
       break;
 
     case 6000:
-      val = E_MIPS_ARCH_2;
+      val = E_MIPS_ARCH_6;
       break;
 
     case 4000:
@@ -2296,6 +2296,14 @@ _bfd_mips_elf_fake_sections (abfd, hdr, sec)
 	hdr->sh_entsize = 0;
       else
 	hdr->sh_entsize = 1;
+    }
+ else if (strcmp (name, ".MIPS.abiflags") == 0)
+    {
+      hdr->sh_type = SHT_MIPS_ABIFLAGS;
+      hdr->sh_entsize = 0x18;
+
+      /* Force the section size to the correct value */
+      hdr->sh_size = sec->_raw_size = 0x18;
     }
   else if (strcmp (name, ".reginfo") == 0)
     {

--- a/gas/config/obj-elf.c
+++ b/gas/config/obj-elf.c
@@ -23,6 +23,8 @@
 #include "subsegs.h"
 #include "obstack.h"
 
+extern int mips_debug;
+
 #ifndef ECOFF_DEBUGGING
 #define ECOFF_DEBUGGING 0
 #else
@@ -1228,7 +1230,7 @@ obj_elf_init_stab_section (seg)
   /* Zero it out. */
   memset (p, 0, 12);
   as_where (&file, (unsigned int *) NULL);
-  stabstr_name = (char *) alloca (strlen (segment_name (seg)) + 4);
+  stabstr_name = (char *) malloc (strlen (segment_name (seg)) + 4);
   strcpy (stabstr_name, segment_name (seg));
   strcat (stabstr_name, "str");
   stroff = get_stab_string_offset (file, stabstr_name);
@@ -1504,6 +1506,7 @@ elf_frob_file_after_relocs ()
 	as_fatal ("Failed to set up debugging information: %s",
 		  bfd_errmsg (bfd_get_error ()));
 
+      if(mips_debug < 2) {
       sec = bfd_get_section_by_name (stdoutput, ".mdebug");
       assert (sec != NULL);
 
@@ -1527,6 +1530,7 @@ elf_frob_file_after_relocs ()
 				   sec->filepos))
 	as_fatal ("Could not write .mdebug section: %s",
 		  bfd_errmsg (bfd_get_error ()));
+      }
     }
 #endif /* NEED_ECOFF_DEBUG */
 }

--- a/gas/config/obj-elf.h
+++ b/gas/config/obj-elf.h
@@ -159,6 +159,7 @@ extern void obj_elf_init_stab_section PARAMS ((segT));
 
 /* We smuggle stabs in ECOFF rather than using a separate section.
    The Irix linker can not handle a separate stabs section.  */
+/*
 #undef SEPARATE_STAB_SECTIONS
 #undef INIT_STAB_SECTION
 #define OBJ_PROCESS_STAB(seg, what, string, type, other, desc) \
@@ -166,7 +167,7 @@ extern void obj_elf_init_stab_section PARAMS ((segT));
 
 #define OBJ_GENERATE_ASM_LINENO(filename, lineno) \
   ecoff_generate_asm_lineno ((filename), (lineno))
-
+*/
 #endif /* ECOFF_DEBUGGING */
 
 extern void elf_frob_symbol PARAMS ((struct symbol *, int *));

--- a/gas/config/tc-mips.h
+++ b/gas/config/tc-mips.h
@@ -150,4 +150,6 @@ extern void mips_flush_pending_output PARAMS ((void));
 extern void mips_enable_auto_align PARAMS ((void));
 #define md_elf_section_change_hook()	mips_enable_auto_align()
 
+extern int mips_debug;
+
 #endif /* TC_MIPS */

--- a/gas/ecoff.c
+++ b/gas/ecoff.c
@@ -28,7 +28,7 @@
    ECOFF debugging information (e.g., MIPS ECOFF, MIPS ELF, Alpha
    ECOFF).  */
 
-#ifdef ECOFF_DEBUGGING
+#if ECOFF_DEBUGGING
 
 #include "coff/internal.h"
 #include "coff/symconst.h"
@@ -3168,6 +3168,11 @@ ecoff_directive_file (ignore)
 
   /* FIXME: we don't have to save the name here.  */
   name = demand_copy_C_string (&len);
+
+  symbolS *sym;
+  sym = symbol_new(name, absolute_section, 0, &zero_address_frag);
+  sym->bsym->flags |= BSF_FILE;
+  symbol_table_insert(sym);
 
   add_file (name, indx - 1, 0);
 

--- a/gas/stabs.c
+++ b/gas/stabs.c
@@ -61,7 +61,7 @@ static void s_stab_generic PARAMS ((int, char *, char *));
  */
 
 #ifndef SEPARATE_STAB_SECTIONS
-#define SEPARATE_STAB_SECTIONS 0
+#define SEPARATE_STAB_SECTIONS 1
 #endif
 
 unsigned int
@@ -284,9 +284,13 @@ s_stab_generic (what, stab_secname, stabstr_secname)
       char *p;
 
       static segT cached_sec;
-      static char *cached_secname;
+      static char *cached_secname = 0;
 
       dot = frag_now_fix ();
+
+#ifdef md_flush_pending_output
+      md_flush_pending_output ();
+#endif
 
       if (cached_secname && !strcmp (cached_secname, stab_secname))
 	{

--- a/gas/symbols.c
+++ b/gas/symbols.c
@@ -141,6 +141,7 @@ symbol_create (name, segment, valu, frag)
   S_SET_VALUE (symbolP, valu);
   symbol_clear_list_pointers (symbolP);
 
+  symbolP->written = (memcmp(preserved_copy_of_name, ".L", 2) != 0);
   symbolP->sy_frag = frag;
 #ifndef BFD_ASSEMBLER
   symbolP->sy_number = ~0;

--- a/gas/write.c
+++ b/gas/write.c
@@ -1803,7 +1803,7 @@ write_object_file ()
 	  /* Skip symbols which were equated to undefined or common
              symbols.  */
 	  if (symp->sy_value.X_op == O_symbol
-	      && (! S_IS_DEFINED (symp) || S_IS_COMMON (symp)))
+	      && (! S_IS_DEFINED (symp) || S_IS_COMMON (symp)) || !symp->written)
 	    {
 	      symbol_remove (symp, &symbol_rootP, &symbol_lastP);
 	      continue;

--- a/include/elf/mips.h
+++ b/include/elf/mips.h
@@ -56,6 +56,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 /* -mips4 code.  */
 #define E_MIPS_ARCH_4		0x30000000
+
+/* -mips64 code.  */
+#define E_MIPS_ARCH_6          0x60000000
 
 /* Processor specific section indices.  These sections do not actually
    exist.  Symbols with a st_shndx field corresponding to one of these
@@ -123,6 +126,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 /* Events section.  */
 #define SHT_MIPS_EVENTS		0x70000021
+
+/* ABI related flags section.  */
+#define SHT_MIPS_ABIFLAGS       0x7000002a
 
 /* A section of type SHT_MIPS_LIBLIST contains an array of the
    following structure.  The sh_link field is the section index of the


### PR DESCRIPTION
gcc 2.8 is extremely old resulting in various issues with newer gdb versions that crash the debugger. These changes alter sections and indicators to gdb about the mips binary including indicating it is a 64bit setup while disabling the problematic .mdebug section if -ggdb3 is being used while maintaining it for lesser debug setups.